### PR TITLE
刷新bean时，判断目标对象是否被代理，获取真实对象。

### DIFF
--- a/xxl-conf-core/pom.xml
+++ b/xxl-conf-core/pom.xml
@@ -36,6 +36,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- spring-aop -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+			<version>${spring.version}</version>
+			<optional>true</optional>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/xxl-conf-core/src/main/java/com/xxl/conf/core/spring/XxlConfFactory.java
+++ b/xxl-conf-core/src/main/java/com/xxl/conf/core/spring/XxlConfFactory.java
@@ -5,6 +5,7 @@ import com.xxl.conf.core.annotation.XxlConf;
 import com.xxl.conf.core.exception.XxlConfException;
 import com.xxl.conf.core.factory.XxlConfBaseFactory;
 import com.xxl.conf.core.listener.impl.BeanRefreshXxlConfListener;
+import com.xxl.conf.core.util.AopTargetUtils;
 import com.xxl.conf.core.util.FieldReflectionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,7 +183,7 @@ public class XxlConfFactory extends InstantiationAwareBeanPostProcessorAdapter
 					beanField.getBeanName(), beanField.getProperty(), value);
 		} else {
 
-			final Object finalBean = bean;
+			final Object finalBean = AopTargetUtils.getTarget(bean); // get real object
 			ReflectionUtils.doWithFields(bean.getClass(), new ReflectionUtils.FieldCallback() {
 				@Override
 				public void doWith(Field fieldItem) throws IllegalArgumentException, IllegalAccessException {

--- a/xxl-conf-core/src/main/java/com/xxl/conf/core/util/AopTargetUtils.java
+++ b/xxl-conf-core/src/main/java/com/xxl/conf/core/util/AopTargetUtils.java
@@ -1,0 +1,57 @@
+package com.xxl.conf.core.util;
+
+import com.xxl.conf.core.exception.XxlConfException;
+import org.springframework.aop.framework.AdvisedSupport;
+import org.springframework.aop.framework.AopProxy;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Field;
+
+/**
+ * @Author: CipherCui
+ * @Description: 获取目标对象
+ * @Date: Created in 21:15 2019/1/11
+ */
+public class AopTargetUtils {
+
+    /**
+     * 获取 目标对象
+     *
+     * @param proxy 代理对象
+     * @return 目标对象
+     */
+    public static Object getTarget(Object proxy) {
+        if (!AopUtils.isAopProxy(proxy)) {
+            return proxy;
+        }
+        try {
+            if (AopUtils.isJdkDynamicProxy(proxy)) {
+                proxy = getJdkDynamicProxyTargetObject(proxy);
+            } else {
+                proxy = getCglibProxyTargetObject(proxy);
+            }
+        } catch (Exception e) {
+            throw new XxlConfException(e);
+        }
+        return getTarget(proxy);
+    }
+
+    private static Object getCglibProxyTargetObject(Object proxy) throws Exception {
+        Field h = proxy.getClass().getDeclaredField("CGLIB$CALLBACK_0");
+        h.setAccessible(true);
+        Object dynamicAdvisedInterceptor = h.get(proxy);
+        Field advised = dynamicAdvisedInterceptor.getClass().getDeclaredField("advised");
+        advised.setAccessible(true);
+        return ((AdvisedSupport) advised.get(dynamicAdvisedInterceptor)).getTargetSource().getTarget();
+    }
+
+    private static Object getJdkDynamicProxyTargetObject(Object proxy) throws Exception {
+        Field h = proxy.getClass().getSuperclass().getDeclaredField("h");
+        h.setAccessible(true);
+        AopProxy aopProxy = (AopProxy) h.get(proxy);
+        Field advised = aopProxy.getClass().getDeclaredField("advised");
+        advised.setAccessible(true);
+        return ((AdvisedSupport) advised.get(aopProxy)).getTargetSource().getTarget();
+    }
+
+}


### PR DESCRIPTION
使用`@XxlConf`注入配置时，如果没有`Setter`方法，而且当前`bean`被代理后，不能动态刷新配置。

虽然，让使用者通过`API`的方式，或者为配置变量添加`set`方法也可以，但不是所有开发者都能注意到这一点。

因此，刷新`bean`时，判断目标对象是否被代理，获取真实对象。

望采纳：）