### PR TITLE
fix read problem when character is not English

### DIFF
--- a/xxl-conf-core/src/main/java/com/xxl/conf/core/util/BasicHttpUtil.java
+++ b/xxl-conf-core/src/main/java/com/xxl/conf/core/util/BasicHttpUtil.java
@@ -8,6 +8,7 @@ import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 /**
  * @author xuxueli 2018-11-25 00:55:31
@@ -65,7 +66,7 @@ public class BasicHttpUtil {
             }
 
             // result
-            bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charset.forName("UTF-8")));
             StringBuilder result = new StringBuilder();
             String line;
             while ((line = bufferedReader.readLine()) != null) {


### PR DESCRIPTION
when config value is not english alphabet, like special character: mm;MPa;℃;Kg/h;MPa;m³;pcs
will display garbled character，so we need read by utf-8.
